### PR TITLE
Updated Micronaut 3.6.0. Removed GVME 22.2 module path workaround.

### DIFF
--- a/oci-build-examples/oci_devops_graalee_micronaut/build_spec.yaml
+++ b/oci-build-examples/oci_devops_graalee_micronaut/build_spec.yaml
@@ -10,8 +10,6 @@ env:
     # However, PATH can be changed in a build step and the change is visible in subsequent steps.
     TAG: "mn-hello-ni:0.0.1"
     APP_FILE: "MnHelloRest"
-    ## TEMPORARY WORKAROUND FOR GVME 22.2
-    USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM: false
 
   # exportedVariables are made available to use as parameters in sucessor Build Pipeline stages
   # For this Build to run, the Build Pipeline needs to have a BUILDRUN_HASH parameter set

--- a/oci-build-examples/oci_devops_graalee_micronaut/build_spec_verbose.yaml
+++ b/oci-build-examples/oci_devops_graalee_micronaut/build_spec_verbose.yaml
@@ -13,8 +13,6 @@ env:
     # However, PATH can be changed in a build step and the change is visible in subsequent steps.
     TAG: "mn-hello-ni:0.0.1"
     APP_FILE: "MnHelloRest"
-    ## TEMPORARY WORKAROUND FOR GVME 22.2
-    USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM: false
 
   # exportedVariables are made available to use as parameters in sucessor Build Pipeline stages
   # For this Build to run, the Build Pipeline needs to have a BUILDRUN_HASH parameter set

--- a/oci-build-examples/oci_devops_graalee_micronaut/pom.xml
+++ b/oci-build-examples/oci_devops_graalee_micronaut/pom.xml
@@ -10,14 +10,14 @@
   <parent>
     <groupId>io.micronaut</groupId>
     <artifactId>micronaut-parent</artifactId>
-    <version>3.5.2</version>
+    <version>3.6.0</version>
   </parent>
 
   <properties>
     <packaging>jar</packaging>
     <jdk.version>17</jdk.version>
     <release.version>17</release.version>
-    <micronaut.version>3.5.2</micronaut.version>
+    <micronaut.version>3.6.0</micronaut.version>
     <micronaut.runtime>netty</micronaut.runtime>
     <exec.mainClass>com.example.Application</exec.mainClass>
   </properties>


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issues)

New samples # (demos / Illustrations )

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?


- [ ] Free Tier
- [ ] Always Free
- [ ] Paid 


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Updated/Sorted AIO.md file
- [ ] My changes generate no new warnings.
- [ ] All the sensitive informations are masked or removed.
- [ ] All the links mentioned are valid and tested.
- [ ] Image names are seperated only with '-'.
- [ ] Added instruction to clone only this sample and links to other common sample pages. 
